### PR TITLE
Filter out non-running pods

### DIFF
--- a/kubectl-view-utilization
+++ b/kubectl-view-utilization
@@ -47,7 +47,7 @@ memory_prettify() {
 utilization_namespaces() {
     local pods_all_requests
 
-    pods_all_requests_with_namespaces=$(kubectl get pod --all-namespaces -o=go-template --template='{{/* pods all requests with namespaces */}}{{range .items}}{{ $n:=.metadata.namespace }}{{range .spec.containers}}{{ $n }}{{"\t"}}{{ if .resources.requests.cpu }}{{ .resources.requests.cpu }}{{end}}{{"\t"}}{{ if .resources.requests.memory }}{{ .resources.requests.memory }}{{end}}{{"\n"}}{{end}}{{end}}')
+    pods_all_requests_with_namespaces=$(kubectl get pod --all-namespaces --field-selector=status.phase=Running -o=go-template --template='{{/* pods all requests with namespaces */}}{{range .items}}{{ $n:=.metadata.namespace }}{{range .spec.containers}}{{ $n }}{{"\t"}}{{ if .resources.requests.cpu }}{{ .resources.requests.cpu }}{{end}}{{"\t"}}{{ if .resources.requests.memory }}{{ .resources.requests.memory }}{{end}}{{"\n"}}{{end}}{{end}}')
     #echo "${pods_all_requests_with_namespaces}"
 
     total_cpu_requests_per_namespace_m=$(echo "${pods_all_requests_with_namespaces}" | \
@@ -138,7 +138,7 @@ utilization_cluster() {
         namespace="--all-namespaces"
     fi
 
-    pods_all_requests=$(kubectl get pod ${namespace} -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}")
+    pods_all_requests=$(kubectl get pod ${namespace} --field-selector=status.phase=Running -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}")
     total_cpu_requests_m=$(echo "${pods_all_requests}" | \
         awk \
       'BEGIN{IGNORECASE = 1}

--- a/test/mocks/kubectl
+++ b/test/mocks/kubectl
@@ -17,12 +17,12 @@ kubectl() {
     fi
 
     # get all pod requests
-    if [ "${1}" == "get" ] && [ "${2}" == "pod" ] && [ "${3}" == "--all-namespaces" ] && [ "${4}" == "-o=jsonpath={range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}" ]; then
+    if [ "${1}" == "get" ] && [ "${2}" == "pod" ] && [ "${3}" == "--all-namespaces" ] && [ "${4}" == "--field-selector=status.phase=Running" ] && [ "${5}" == "-o=jsonpath={range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}" ]; then
         kubectl_get_all_pods_requests
     fi
 
     # get all pod requests and with namespaces
-    if [ "${1}" == "get" ] && [ "${2}" == "pod" ] && [ "${3}" == "--all-namespaces" ] && [ "${4}" == "-o=go-template" ] && [[ "${5}" == *"pods all requests with namespaces"* ]]; then
+    if [ "${1}" == "get" ] && [ "${2}" == "pod" ] && [ "${3}" == "--all-namespaces" ] && [ "${4}" == "--field-selector=status.phase=Running" ] && [ "${5}" == "-o=go-template" ] && [[ "${6}" == *"pods all requests with namespaces"* ]]; then
         kubectl_get_all_pods_requests_with_namespaces
     fi
 

--- a/test/utilization.bats
+++ b/test/utilization.bats
@@ -60,7 +60,7 @@ switch_context() {
 @test "cluster-small> kubectl get pod requests cpu and memory" {
 
     switch_context cluster-small
-    run kubectl get pod --all-namespaces -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
+    run kubectl get pod --all-namespaces --field-selector=status.phase=Running -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
     [ $status -eq 0 ]
     echo "output = ${output}"
     [[ "${lines[0]}" == "10m" ]]
@@ -71,7 +71,7 @@ switch_context() {
 @test "cluster-medium> kubectl get pod requests cpu and memory" {
 
     switch_context cluster-medium
-    run kubectl get pod --all-namespaces -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
+    run kubectl get pod --all-namespaces --field-selector=status.phase=Running -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
     [ $status -eq 0 ]
     echo "output = ${output}"
     [[ "${lines[0]}" == "10m" ]]
@@ -80,7 +80,7 @@ switch_context() {
 @test "cluster-big> kubectl get pod requests cpu and memory" {
 
     switch_context cluster-big
-    run kubectl get pod --all-namespaces -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
+    run kubectl get pod --all-namespaces --field-selector=status.phase=Running -o=jsonpath="{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{'\t'}{.resources.requests.memory}{'\n'}{end}{'\n'}{end}"
     [ $status -eq 0 ]
     echo "output = ${output}"
     [[ "${lines[0]}" == "10m" ]]


### PR DESCRIPTION
I was seeing results where the total resource allocation (i.e. sum of all resource requests) was > 100%, which is not technically possible since the scheduler will refuse to schedule pods based on resource requests in that case.

This adds a filter based on the pod status to including only running pods.

Sample output on the same cluster from before:
```
cores       34 / 18      (188%)
memory   78GiB / 67GiB   (117%)
```
...and after:
```
cores      9.8 / 18      (54%)
memory   20GiB / 67GiB   (30%)
```

Hope this makes sense... 😃 