### PR TITLE
Calculation fix

### DIFF
--- a/kubectl-view-utilization
+++ b/kubectl-view-utilization
@@ -100,7 +100,8 @@ cluster_utilization() {
     $2 in node && $3 ~ /m?$/    { req_cpu+=$3; };
 
     # memory requests
-    $2 in node && $4 ~ /M(i)?$/ { req_mem+=$4*1024;$3; next };
+    $2 in node && $4 ~ /K(i)?$/ { req_mem+=$4; next };
+    $2 in node && $4 ~ /M(i)?$/ { req_mem+=$4*1024; next };
     $2 in node && $4 ~ /G(i)?$/ { req_mem+=$4*1048576; next };
     $2 in node && $4 ~ /T(i)?$/ { req_mem+=$4*1073741824; next };
     END {
@@ -116,6 +117,7 @@ namespace_utilization() {
 
     awk \
     "$VIEW_UTILIZATION_AWK_FN"'
+    BEGIN {FS="\t"};
     namespaces[$1];
 
     # CPU requests
@@ -123,7 +125,8 @@ namespace_utilization() {
     $3 ~ /m?$/    { req_cpu[$1]+=$3; };
 
     # memory requests
-    $4 ~ /M(i)?$/ { req_mem[$1]+=$4*1024;$3; next };
+    $4 ~ /K(i)?$/ { req_mem[$1]+=$4; next };
+    $4 ~ /M(i)?$/ { req_mem[$1]+=$4*1024; next };
     $4 ~ /G(i)?$/ { req_mem[$1]+=$4*1048576; next };
     $4 ~ /T(i)?$/ { req_mem[$1]+=$4*1073741824; next };
 
@@ -135,6 +138,7 @@ namespace_utilization() {
             i++;
             if (longest_namespace_len < length(namespace)) longest_namespace_len = length(namespace)
         }
+        if (longest_namespace_len < 9 ) longest_namespace_len = 9
 
         printf("%-" longest_namespace_len "s%8s%10s\n", "NAMESPACE", "CPU", "MEMORY")
 

--- a/kubectl-view-utilization
+++ b/kubectl-view-utilization
@@ -89,11 +89,12 @@ cluster_utilization() {
 
     awk \
     "$VIEW_UTILIZATION_AWK_FN"'
+    BEGIN {FS="\t"};
     NR==FNR { node[$1]; } 
 
     NR==FNR && $2 ~ /[0-9]$/ { alloc_cpu+=$2*1000; };
     NR==FNR && $2 ~ /m?$/    { alloc_cpu+=$2; };
-    NR==FNR && $3 ~ /Ki?$/   { alloc_mem+=$3;next };
+    NR==FNR && $3 ~ /Ki?$/   { alloc_mem+=$3; next };
 
     # CPU requests
     $2 in node && $3 ~ /[0-9]$/ { req_cpu+=$3*1000; };

--- a/test/mocks/kubectl.bash
+++ b/test/mocks/kubectl.bash
@@ -31,6 +31,12 @@ kubectl() {
 
 kubectl_get_all_nodes_requests() {
 
+    if [ "${KUBECTL_CONTEXT}" == "cluster-bug1" ]; then 
+        echo "ip-10-1-1-10.us-west-2.compute.internal	2	1351126Ki"
+        echo "ip-10-1-1-11.us-west-2.compute.internal	4	2702252Ki"
+    fi
+
+
     if [ "${KUBECTL_CONTEXT}" == "cluster-small" ]; then 
         echo "ip-10-1-1-10.us-west-2.compute.internal	449m	1351126Ki"
         echo "ip-10-1-1-11.us-west-2.compute.internal	449m	1351126Ki"
@@ -108,7 +114,7 @@ kubectl_get_all_pods_requests_with_namespaces() {
     if [ "${KUBECTL_CONTEXT}" == "cluster-bug1" ]; then 
         echo "infra	ip-10-1-1-10.us-west-2.compute.internal		1G"
         echo "infra	ip-10-1-1-11.us-west-2.compute.internal		1500M"
-        echo "infra	ip-10-1-1-12.us-west-2.compute.internal		937500K"
+        echo "infra	ip-10-1-1-11.us-west-2.compute.internal		937500K"
     fi
 
 

--- a/test/mocks/kubectl.bash
+++ b/test/mocks/kubectl.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 kubectl() {
-    local clusters=(cluster-small cluster-medium cluster-big)
+    local clusters=(cluster-small cluster-medium cluster-big cluster-bug1)
     if [ "${1}" == "config" ] && [ "${2}" == "use-context" ] && [[ "${clusters[*]}" =~ $3 ]]; then
         KUBECTL_CONTEXT="${3}"
         echo "setting context to ${3}"
@@ -104,6 +104,13 @@ kubectl_get_master_nodes_requests() {
 
 
 kubectl_get_all_pods_requests_with_namespaces() {
+
+    if [ "${KUBECTL_CONTEXT}" == "cluster-bug1" ]; then 
+        echo "infra	ip-10-1-1-10.us-west-2.compute.internal		1G"
+        echo "infra	ip-10-1-1-11.us-west-2.compute.internal		1500M"
+        echo "infra	ip-10-1-1-12.us-west-2.compute.internal		937500K"
+    fi
+
 
     if [ "${KUBECTL_CONTEXT}" == "cluster-small" ]; then 
         echo "default	ip-10-1-1-10.us-west-2.compute.internal	10m	"

--- a/test/utilization.bats
+++ b/test/utilization.bats
@@ -327,6 +327,47 @@ switch_context() {
     [[ "${lines[6]}" == "stg              30       60G" ]]
 }
 
+@test "cluster-bug1 (original-awk)> kubectl view-utilization namespaces" {
+
+    use_awk original-awk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization namespaces
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "NAMESPACE     CPU    MEMORY" ]]
+    [[ "${lines[1]}" == "infra           0      3.4G" ]]
+}
+
+@test "cluster-bug1 (gawk)> kubectl view-utilization namespaces" {
+
+    use_awk gawk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization namespaces
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "NAMESPACE     CPU    MEMORY" ]]
+    [[ "${lines[1]}" == "infra           0      3.4G" ]]
+}
+
+@test "cluster-bug1 (mawk)> kubectl view-utilization namespaces" {
+
+    use_awk mawk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization namespaces
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "NAMESPACE     CPU    MEMORY" ]]
+    [[ "${lines[1]}" == "infra           0      3.4G" ]]
+}
+
+
+
 @test "cluster-small (gawk)> kubectl view-utilization masters" {
 
     use_awk gawk

--- a/test/utilization.bats
+++ b/test/utilization.bats
@@ -201,6 +201,45 @@ switch_context() {
     [[ "${lines[1]}" == "memory  144G / 1.6T  (8%)" ]]
 }
 
+@test "cluster-bug1 (original-awk)> kubectl view utilization" {
+
+    use_awk original-awk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "cores      0 / 6     (0%)" ]]
+    [[ "${lines[1]}" == "memory  3.4G / 3.9G  (86%)" ]]
+}
+
+@test "cluster-bug1 (gawk)> kubectl view utilization" {
+
+    use_awk gawk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "cores      0 / 6     (0%)" ]]
+    [[ "${lines[1]}" == "memory  3.4G / 3.9G  (86%)" ]]
+}
+
+@test "cluster-bug1 (mawk)> kubectl view utilization" {
+
+    use_awk mawk
+    switch_context cluster-bug1
+
+    run /code/kubectl-view-utilization
+
+    [ $status -eq 0 ]
+    echo "${output}"
+    [[ "${lines[0]}" == "cores      0 / 6     (0%)" ]]
+    [[ "${lines[1]}" == "memory  3.4G / 3.9G  (86%)" ]]
+}
+
 @test "cluster-small (gawk)> kubectl view-utilization namespaces" {
 
     use_awk gawk


### PR DESCRIPTION
[#21](https://github.com/etopeter/kubectl-view-utilization/issues/21)

Fix for:
- namespaces subcommand with pods without CPU requests
- namespaces subcommand format output with shorter namespaces
- namespaces subcommand totals calculation with Kb in requests
- utilization totals calculation with Kb in requests