### PR TITLE
Memory notation

### DIFF
--- a/kubectl-view-utilization
+++ b/kubectl-view-utilization
@@ -101,10 +101,10 @@ cluster_utilization() {
     $2 in node && $3 ~ /m?$/    { req_cpu+=$3; };
 
     # memory requests
-    $2 in node && $4 ~ /K(i)?$/ { req_mem+=$4; next };
-    $2 in node && $4 ~ /M(i)?$/ { req_mem+=$4*1024; next };
-    $2 in node && $4 ~ /G(i)?$/ { req_mem+=$4*1048576; next };
-    $2 in node && $4 ~ /T(i)?$/ { req_mem+=$4*1073741824; next };
+    $2 in node && $4 ~ /[kK](i)?$/ { req_mem+=$4; next };
+    $2 in node && $4 ~ /[mM](i)?$/ { req_mem+=$4*1024; next };
+    $2 in node && $4 ~ /[gG](i)?$/ { req_mem+=$4*1048576; next };
+    $2 in node && $4 ~ /[tT](i)?$/ { req_mem+=$4*1073741824; next };
     END {
         if ( alloc_cpu > 0 && alloc_mem > 0 ) {
             printf("cores  %5s / %-5s (%d%%)\n", cpu_pretty(req_cpu), cpu_pretty(alloc_cpu), req_cpu * 100 / alloc_cpu);
@@ -126,10 +126,10 @@ namespace_utilization() {
     $3 ~ /m?$/    { req_cpu[$1]+=$3; };
 
     # memory requests
-    $4 ~ /K(i)?$/ { req_mem[$1]+=$4; next };
-    $4 ~ /M(i)?$/ { req_mem[$1]+=$4*1024; next };
-    $4 ~ /G(i)?$/ { req_mem[$1]+=$4*1048576; next };
-    $4 ~ /T(i)?$/ { req_mem[$1]+=$4*1073741824; next };
+    $4 ~ /[kK](i)?$/ { req_mem[$1]+=$4; next };
+    $4 ~ /[mM](i)?$/ { req_mem[$1]+=$4*1024; next };
+    $4 ~ /[gG](i)?$/ { req_mem[$1]+=$4*1048576; next };
+    $4 ~ /[tT](i)?$/ { req_mem[$1]+=$4*1073741824; next };
 
     END {
 

--- a/test/mocks/kubectl.bash
+++ b/test/mocks/kubectl.bash
@@ -114,7 +114,7 @@ kubectl_get_all_pods_requests_with_namespaces() {
     if [ "${KUBECTL_CONTEXT}" == "cluster-bug1" ]; then 
         echo "infra	ip-10-1-1-10.us-west-2.compute.internal		1G"
         echo "infra	ip-10-1-1-11.us-west-2.compute.internal		1500M"
-        echo "infra	ip-10-1-1-11.us-west-2.compute.internal		937500K"
+        echo "infra	ip-10-1-1-11.us-west-2.compute.internal		937500k"
     fi
 
 


### PR DESCRIPTION
This is fix for issue [#21](https://github.com/etopeter/kubectl-view-utilization/issues/21)
Fixes memory outputs using lower case characters.